### PR TITLE
Add support for template-haskell 2.16.

### DIFF
--- a/haskell-src-meta/haskell-src-meta.cabal
+++ b/haskell-src-meta/haskell-src-meta.cabal
@@ -21,7 +21,7 @@ library
                    haskell-src-exts >= 1.18 && < 1.23,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.8,
-                   template-haskell >= 2.10 && < 2.16,
+                   template-haskell >= 2.10 && < 2.17,
                    th-orphans >= 0.12 && < 0.14
 
   if impl(ghc < 7.8)

--- a/haskell-src-meta/src/Language/Haskell/Meta/Utils.hs
+++ b/haskell-src-meta/src/Language/Haskell/Meta/Utils.hs
@@ -331,10 +331,11 @@ fromDataConI (DataConI dConN ty _tyConN) =
       >>= \ns -> return (Just (LamE
                     [ConP dConN (fmap VarP ns)]
 #if MIN_VERSION_template_haskell(2,16,0)
-                    (TupE $ fmap (Just . VarE) ns)))
+                    (TupE $ fmap (Just . VarE) ns)
 #else
-                    (TupE $ fmap VarE ns)))
+                    (TupE $ fmap VarE ns)
 #endif
+                    ))
 #else
 fromDataConI (DataConI dConN ty _tyConN _fxty) =
   let n = arityT ty

--- a/haskell-src-meta/src/Language/Haskell/Meta/Utils.hs
+++ b/haskell-src-meta/src/Language/Haskell/Meta/Utils.hs
@@ -330,7 +330,11 @@ fromDataConI (DataConI dConN ty _tyConN) =
   in replicateM n (newName "a")
       >>= \ns -> return (Just (LamE
                     [ConP dConN (fmap VarP ns)]
+#if MIN_VERSION_template_haskell(2,16,0)
+                    (TupE $ fmap (Just . VarE) ns)))
+#else
                     (TupE $ fmap VarE ns)))
+#endif
 #else
 fromDataConI (DataConI dConN ty _tyConN _fxty) =
   let n = arityT ty


### PR DESCRIPTION
The commit https://gitlab.haskell.org/ghc/ghc/commit/cef80c0b9edca3d21b5c762f51dfbab4c5857d8a changed `TupE` and `UnboxedTupE` to use lists of `Maybe`s, in order to add support for tuple sections.

With the change in this PR, I was able to build under the new GHC 8.10.1-alpha1.