### PR TITLE
support template-haskell-2.17

### DIFF
--- a/haskell-src-meta/examples/BF.hs
+++ b/haskell-src-meta/examples/BF.hs
@@ -67,7 +67,9 @@ instance Lift Bf where
   lift MovR       = [|MovR|]
   lift (While xs) = [|While $(lift xs)|]
 
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_template_haskell(2,17,0)
+  liftTyped = unsafeCodeCoerce . lift
+#elif MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeTExpCoerce . lift
   -- TODO: get stylish haskell to be happy w/ the below
   -- liftTyped Inp        = [||Inp||]

--- a/haskell-src-meta/examples/HsHere.hs
+++ b/haskell-src-meta/examples/HsHere.hs
@@ -60,15 +60,15 @@ here = QuasiQuoter
         ,quotePat = herePatQ}
 
 instance Lift Here where
-  lift = liftHere
-#if MIN_VERSION_template_haskell(2,16,0)
+  lift (TextH s)  = (litE . stringL) s
+  lift (CodeH e)  = [|show $(return e)|]
+  lift (ManyH hs) = [|concat $(listE (fmap lift hs))|]
+
+#if MIN_VERSION_template_haskell(2,17,0)
+  liftTyped = unsafeCodeCoerce . lift
+#elif MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeTExpCoerce . lift -- TODO: the right way?
 #endif
-
-liftHere :: Here -> ExpQ
-liftHere (TextH s)  = (litE . stringL) s
-liftHere (CodeH e)  = [|show $(return e)|]
-liftHere (ManyH hs) = [|concat $(listE (fmap liftHere hs))|]
 
 
 hereExpQ :: String -> ExpQ

--- a/haskell-src-meta/examples/SKI.hs
+++ b/haskell-src-meta/examples/SKI.hs
@@ -71,7 +71,9 @@ ski = QuasiQuoter
 
 instance Lift SKI where
   lift = liftSKI
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_template_haskell(2,17,0)
+  liftTyped = unsafeCodeCoerce . lift
+#elif MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeTExpCoerce . lift -- TODO: the right way?
 #endif
 

--- a/haskell-src-meta/haskell-src-meta.cabal
+++ b/haskell-src-meta/haskell-src-meta.cabal
@@ -21,7 +21,7 @@ library
                    haskell-src-exts >= 1.18 && < 1.24,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.8,
-                   template-haskell >= 2.10 && < 2.17,
+                   template-haskell >= 2.10 && < 2.18,
                    th-orphans >= 0.12 && < 0.14
 
   if impl(ghc < 7.8)

--- a/haskell-src-meta/src/Language/Haskell/Meta/Utils.hs
+++ b/haskell-src-meta/src/Language/Haskell/Meta/Utils.hs
@@ -161,7 +161,11 @@ renameT env new (ForallT ns cxt t) =
         (t',env4,new4) = renameT env3 new3 t
     in (ForallT ns'' cxt' t', env4, new4)
   where
+#if MIN_VERSION_template_haskell(2,17,0)
+    unVarT (VarT n) = PlainTV n SpecifiedSpec
+#else
     unVarT (VarT n) = PlainTV n
+#endif
     unVarT ty       = error $ "renameT: unVarT: TODO for" ++ show ty
     renamePreds = renameThings renamePred
     renamePred = renameT
@@ -230,7 +234,7 @@ decCons (NewtypeD _ _ _ con _)   = [con]
 decCons _                        = []
 
 
-decTyVars :: Dec -> [TyVarBndr]
+decTyVars :: Dec -> [TyVarBndr_ ()]
 #if MIN_VERSION_template_haskell(2,11,0)
 decTyVars (DataD _ _ ns _ _ _)    = ns
 decTyVars (NewtypeD _ _ ns _ _ _) = ns


### PR DESCRIPTION
Depends on DanielSchuessler/th-expand-syns#18 or DanielSchuessler/th-expand-syns#19

Most of the changes are due to https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#template-haskell-217
I defaulted to `SpecifiedSpec` (so that `TypeApplications` can be used), but I don't think that this really matters.

Tested locally with this `cabal.project.local`:

```
with-compiler: ghc-9.0.1
source-repository-package
  type: git
  location: https://github.com/mgsloan/th-expand-syns
  tag: 6a64927ebd6b85cc3c67c00c88c3c7c019d31573
```