### PR TITLE
Add TypeApplications to default extensions

### DIFF
--- a/haskell-src-meta/ChangeLog
+++ b/haskell-src-meta/ChangeLog
@@ -1,3 +1,6 @@
+NEXT:
+- Add TypeApplications to default extensions
+
 0.8.5:
 - Compatibility with template-haskell shipped with GHC 8.10
 

--- a/haskell-src-meta/src/Language/Haskell/Meta/Parse.hs
+++ b/haskell-src-meta/src/Language/Haskell/Meta/Parse.hs
@@ -84,7 +84,8 @@ myDefaultExtensions = [PostfixOperators
                       ,TemplateHaskell
                       ,RankNTypes
                       ,MultiParamTypeClasses
-                      ,RecursiveDo]
+                      ,RecursiveDo
+                      ,TypeApplications]
 
 parseResultToEither :: ParseResult a -> Either String a
 parseResultToEither (ParseOk a) = Right a


### PR DESCRIPTION
Ping @sol

I'm a couple of dependencies deep here. My use case is that I want to use type applications inside aeson-qq:

```haskell
instance Example Foo where
  example = [aesonQQ| { "bar": #{example @Bar} }|]
```

alternatively this could be added to aeson-qq
```haskell
 module Data.JSON.QQ (JsonValue (..), HashKey (..), parsedJson) where

 import           Control.Applicative
-import           Language.Haskell.TH
+import           Language.Haskell.Exts.Extension (Extension (EnableExtension), KnownExtension (TypeApplications))
+import           Language.Haskell.TH (Exp)
 import           Text.ParserCombinators.Parsec hiding (many, (<|>))
-import           Language.Haskell.Meta.Parse
+import qualified Language.Haskell.Meta.Parse as Meta
+import qualified Language.Haskell.Meta.Syntax.Translate as Meta
 import qualified Data.Attoparsec.Text as A
 import           Data.Scientific (Scientific)
 import qualified Data.Text as T
+import Language.Haskell.Exts.Parser (parseExpWithMode, defaultParseMode, extensions)

 parsedJson :: String -> Either ParseError JsonValue
 parsedJson = parse (jpValue <* eof) "txt"
@@ -50,6 +53,10 @@ jpCode = JsonCode <$> (string "#{" *> parseExp')
         Left l -> fail l
         Right r -> return r

+parseExp = either Left (Right . Meta.toExp) . parseHsExp
+  where
+    parseHsExp = Meta.parseResultToEither . parseExpWithMode defaultParseMode { extensions = EnableExtension TypeApplications : extensions defaultParseMode }
+
 jpNull :: JsonParser
 jpNull = string "null" *> pure JsonNull
 ```

smaller diff in this project so I went with that :-) Is it fine to add it or are there reasons not to?
