### PR TITLE
bump lower bound of `haskell-src-exts` dependency

### DIFF
--- a/haskell-src-meta/haskell-src-meta.cabal
+++ b/haskell-src-meta/haskell-src-meta.cabal
@@ -19,7 +19,7 @@ extra-source-files: ChangeLog README.md
 library
   default-language: Haskell2010
   build-depends:   base >= 4.10 && < 5,
-                   haskell-src-exts >= 1.18 && < 1.24,
+                   haskell-src-exts >= 1.21 && < 1.24,
                    pretty >= 1.0 && < 1.2,
                    syb >= 0.1 && < 0.8,
                    template-haskell >= 2.12 && < 2.19,
@@ -41,7 +41,7 @@ test-suite unit
   build-depends:
     HUnit                >= 1.2,
     base                 >= 4.10,
-    haskell-src-exts     >= 1.17,
+    haskell-src-exts     >= 1.21,
     haskell-src-meta,
     pretty               >= 1.0,
     template-haskell     >= 2.12,


### PR DESCRIPTION
Closes https://github.com/haskell-party/haskell-src-meta/issues/31